### PR TITLE
Fix spacing between date, time and location elements

### DIFF
--- a/src/components/HeadSection/index.js
+++ b/src/components/HeadSection/index.js
@@ -29,6 +29,7 @@ const HeadSection = () => {
               alignContent: "center",
               borderLeft: "3px solid #bca459",
               borderRight: "3px solid #bca459",
+              display: 'flex',
               height: "100%",
               margin: "12px",
               width: "100%",

--- a/src/components/HeadSection/styles.module.css
+++ b/src/components/HeadSection/styles.module.css
@@ -90,6 +90,7 @@
   justify-items: center;
   margin: 18px auto;
   max-width: 600px;
+  row-gap: 12px;
   width: 80%;
 }
 


### PR DESCRIPTION
## Description
There's not enough spacing between date, time & location elements. Also the location element was centered inside the cell.